### PR TITLE
Criação do RetrospectiveDecorator

### DIFF
--- a/app/controllers/retrospectives_controller.rb
+++ b/app/controllers/retrospectives_controller.rb
@@ -5,7 +5,8 @@ class RetrospectivesController < ApplicationController
   end
 
   def new
-    @retrospective = Retrospective.new(team: current_team)
+    @retrospective = RetrospectiveDecorator.new(Retrospective
+                                                .new(team: current_team))
   end
 
   def create
@@ -17,7 +18,9 @@ class RetrospectivesController < ApplicationController
   end
 
   def edit
-    @retrospective = current_team.retrospectives.find(params[:id])
+    @retrospective = RetrospectiveDecorator.new(current_team
+                                                .retrospectives
+                                                .find(params[:id]))
   end
 
   def update

--- a/app/decorators/retrospective_decorator.rb
+++ b/app/decorators/retrospective_decorator.rb
@@ -1,0 +1,7 @@
+require 'delegate'
+
+class RetrospectiveDecorator < SimpleDelegator
+  def schedule
+    super.strftime('%H:%M') if super.present?
+  end
+end

--- a/app/views/retrospectives/_form.html.erb
+++ b/app/views/retrospectives/_form.html.erb
@@ -23,7 +23,7 @@
       <div class="col-md-4">
         <label class="ls-label">
           <b class="ls-label-text"><%= t('form.schedule') %>:</b>
-          <%= f.time_field :schedule, required: true %>
+          <%= f.time_field :schedule, value: @retrospective.schedule, required: true %>
         </label>
       </div>
       <div class="col-md-12">

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module LwRetro
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.autoload_paths << "#{config.root}/app/decorator"
   end
 end

--- a/spec/decorators/retrospective_decorator_spec.rb
+++ b/spec/decorators/retrospective_decorator_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe RetrospectiveDecorator do
+  let(:retrospective) { create(:retrospective, schedule: Time.parse('15:00')) }
+  let(:decorator) { described_class.new(retrospective) }
+
+  describe '#schedule' do
+    it 'returns formatted schedule with just hours and minutes' do
+      expect(decorator.schedule).to eq('15:00')
+    end
+  end
+end


### PR DESCRIPTION
Existia um bug na edição de uma retrospectiva, pois a mesma preenchia o campo de hora com o `value` que não é aceito na validação front-end.

Para evitar esse erro, foi criado um decorator de retrospectiva para formatar o horário em `%H:%M` e eliminar o erro.